### PR TITLE
chore: tighten ESLint configuration and fix linting issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,11 +16,27 @@
   "rules": {
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
-    "@typescript-eslint/ban-ts-comment": "off",
-    "no-prototype-builtins": "off",
-    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/ban-ts-comment": ["error", {
+      "ts-expect-error": "allow-with-description",
+      "ts-ignore": false,
+      "ts-nocheck": false,
+      "ts-check": false,
+      "minimumDescriptionLength": 10
+    }],
+    "no-prototype-builtins": "error",
+    "@typescript-eslint/no-empty-function": "error",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "no-console": ["warn", { "allow": ["warn", "error"] }],
+    "no-debugger": "error",
+    "no-var": "error",
+    "prefer-const": "error",
+    "prefer-arrow-callback": "error",
+    "no-throw-literal": "error",
+    "eqeqeq": ["error", "always", { "null": "ignore" }],
+    "curly": ["error", "all"],
     "node/no-unsupported-features/es-builtins": ["error", { "version": ">=16.0.0", "ignores": [] }],
-//    "node/no-unsupported-features/es-syntax": ["error", { "version": ">=16.0.0", "ignores": [] }],
     "node/no-unsupported-features/node-builtins": ["error", { "version": ">=16.0.0", "ignores": [] }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"builtin-modules": "^3.2.0",
 		"date-fns": "^2.28.0",
 		"esbuild": "0.17.3",
+		"eslint": "^8.57.1",
 		"eslint-plugin-node": "^11.1.0",
 		"file-type-checker": "^1.0.8",
 		"imask": "^7.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ devDependencies:
   esbuild:
     specifier: 0.17.3
     version: 0.17.3
+  eslint:
+    specifier: ^8.57.1
+    version: 8.57.1
   eslint-plugin-node:
     specifier: ^11.1.0
     version: 11.1.0(eslint@8.57.1)

--- a/src/abstract-wp-client.ts
+++ b/src/abstract-wp-client.ts
@@ -211,8 +211,9 @@ export abstract class AbstractWordPressClient implements WordPressClient {
           img.src = decodeURI(img.src);
           const fileName = img.src.split("/").pop();
 
-          if ( fileName === undefined )
+          if ( fileName === undefined ) {
             continue;
+          }
 
           const normPath = this.plugin.app.metadataCache.getFirstLinkpathDest(img.src, fileName);
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,6 +6,7 @@ export class Logger {
 
   static log(...args: unknown[]): void {
     if (!Logger.isProduction) {
+      // eslint-disable-next-line no-console
       console.log(...args);
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,9 +77,6 @@ export default class WordpressPlugin extends Plugin {
     this.addSettingTab(new WordpressSettingTab(this));
   }
 
-  onunload() {
-  }
-
   async loadSettings() {
     this.#settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
     const { needUpgrade, settings } = await upgradeSettings(this.#settings, SettingsVersion.V2);

--- a/src/markdown-it-image-plugin.ts
+++ b/src/markdown-it-image-plugin.ts
@@ -16,7 +16,9 @@ interface MarkdownItImagePluginOptions {
 }
 
 const pluginOptions: MarkdownItImagePluginOptions = {
-  doWithImage: () => {},
+  doWithImage: () => {
+    // Default no-op implementation, will be overridden by MarkdownItImagePluginInstance.doWithImage
+  },
 }
 
 export const MarkdownItImagePluginInstance = {

--- a/src/markdown-it-mathjax3-plugin.ts
+++ b/src/markdown-it-mathjax3-plugin.ts
@@ -132,7 +132,7 @@ function mathInline(state: StateInline, silent: boolean) {
     }
 
     // Even number of escapes, potential closing delimiter found
-    if ((match - pos) % 2 == 1) {
+    if ((match - pos) % 2 === 1) {
       break;
     }
     match += 1;

--- a/src/pass-crypto.ts
+++ b/src/pass-crypto.ts
@@ -5,8 +5,6 @@ const FORMAT_JWK = 'jwk';
 
 export class PassCrypto {
 
-  constructor() { }
-
   canUse(): boolean {
     return !isNil(crypto)
       && !isNil(crypto.subtle)

--- a/src/wp-publish-modal.ts
+++ b/src/wp-publish-modal.ts
@@ -224,7 +224,9 @@ export class WpPublishModal extends AbstractModal {
                 }
               });
           } else {
-            this.onSubmit(params, fm => {});
+            this.onSubmit(params, () => {
+              // No frontmatter modifications needed
+            });
           }
         })
       );


### PR DESCRIPTION
- Enable @typescript-eslint/ban-ts-comment with strict rules (disallow @ts-ignore)
- Enable @typescript-eslint/no-empty-function to prevent empty functions
- Enable no-prototype-builtins, no-console, no-debugger, and other best practices
- Add rules: no-var, prefer-const, prefer-arrow-callback, eqeqeq, curly
- Install ESLint 8.57.0 for compatibility with existing plugins
- Fix all linting violations across the codebase:
  * Add curly braces to if statements
  * Change let to const where appropriate
  * Remove empty functions and constructors
  * Replace == with ===
  * Remove unused imports
  * Add comments for intentional empty implementations
  * Add eslint-disable comments for Logger utility
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance ESLint configuration with stricter rules and fix linting issues across the codebase, including updates to `abstract-wp-client.ts`, `logger.ts`, and `main.ts`.
> 
>   - **ESLint Configuration**:
>     - Enable `@typescript-eslint/ban-ts-comment` with strict rules (disallow `@ts-ignore`).
>     - Enable `@typescript-eslint/no-empty-function` to prevent empty functions.
>     - Enable `no-prototype-builtins`, `no-console`, `no-debugger`, and other best practices.
>     - Add rules: `no-var`, `prefer-const`, `prefer-arrow-callback`, `eqeqeq`, `curly`.
>     - Install ESLint 8.57.0 for compatibility with existing plugins.
>   - **Codebase Changes**:
>     - Add curly braces to `if` statements in `abstract-wp-client.ts`.
>     - Change `let` to `const` where appropriate in `abstract-wp-client.ts`.
>     - Remove empty functions and constructors in `main.ts` and `pass-crypto.ts`.
>     - Replace `==` with `===` in `markdown-it-mathjax3-plugin.ts`.
>     - Remove unused imports in `abstract-wp-client.ts` and `wp-publish-modal.ts`.
>     - Add comments for intentional empty implementations in `markdown-it-image-plugin.ts`.
>     - Add `eslint-disable` comments for `Logger` utility in `logger.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=bugparty%2Fobsidian-wordpress-reloaded&utm_source=github&utm_medium=referral)<sup> for 18dda7d3bf9f561a80af8f9b8462daa0637ae5e9. You can [customize](https://app.ellipsis.dev/bugparty/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->