### PR TITLE
feat: support ALT text uploading (only standard Markdown syntax) #11

### DIFF
--- a/src/abstract-wp-client.ts
+++ b/src/abstract-wp-client.ts
@@ -222,7 +222,7 @@ export abstract class AbstractWordPressClient implements WordPressClient {
               }else if (img.width){
                   postParams.content = postParams.content.replace(img.original, `![[${result.data.url}|${img.width}]]`);
               }else{
-                  postParams.content = postParams.content.replace(img.original, `![[${result.data.url}]]`);
+                  postParams.content = postParams.content.replace(img.original, `![${img.altText}](${result.data.url})`);
               }
             } else {
               if (result.error.code === WordPressClientReturnCode.ServerInternalError) {

--- a/src/abstract-wp-client.ts
+++ b/src/abstract-wp-client.ts
@@ -213,7 +213,8 @@ export abstract class AbstractWordPressClient implements WordPressClient {
             const result = await this.uploadMedia({
               mimeType: fileType?.mimeType ?? 'application/octet-stream',
               fileName: imgFile.name,
-              content: content
+              content: content,
+              alt: img.altText
             }, auth);
             if (result.code === WordPressClientReturnCode.OK) {
               if(img.width && img.height){

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface Media {
   mimeType: string;
   fileName: string;
   content: ArrayBuffer;
+  alt?: string;
 }
 
 /**

--- a/src/wp-client.ts
+++ b/src/wp-client.ts
@@ -85,6 +85,7 @@ export interface WordPressPublishResult {
 
 export interface WordPressMediaUploadResult {
   url: string;
+  mediaId?: string;
 }
 
 export interface WordPressClient {

--- a/src/wp-rest-client.ts
+++ b/src/wp-rest-client.ts
@@ -26,6 +26,7 @@ interface WpRestEndpoint {
   getTag: string | UrlGetter;
   validateUser: string | UrlGetter;
   uploadFile: string | UrlGetter;
+  setAlt: string | UrlGetter | undefined;
   getPostTypes: string | UrlGetter;
 }
 
@@ -186,17 +187,24 @@ export class WpRestClient extends AbstractWordPressClient {
         });
       const result = this.context.responseParser.toWordPressMediaUploadResult(response);
 
-      const altResponse: SafeAny = await this.client.httpPost(
-        getUrl(undefined, 'wp-json/wp/v2/media/' + result.mediaId),
-        JSON.stringify({
-          alt_text: media.alt
-        }),
-        {
-          headers: {
-            ...this.context.getHeaders(certificate)
+      if (result.mediaId) {
+        await this.client.httpPost(
+          getUrl(this.context.endpoints?.setAlt, 'wp-json/wp/v2/media/<%= id %>', {
+            id: result.mediaId
+          }),
+          this.context.name === 'WpRestClientWpComOAuth2Context' ?
+          {
+            'alt': media.alt
+          } : {
+            'alt_text': media.alt
+          },
+          {
+            headers: {
+              ...this.context.getHeaders(certificate)
+            }
           }
-        }
-      )
+        );
+      }
 
       return {
         code: WordPressClientReturnCode.OK,
@@ -344,6 +352,7 @@ export class WpRestClientWpComOAuth2Context implements WpRestClientContext {
     getTag: () => `/rest/v1.1/sites/${this.site}/tags?number=1&search=<%= name %>`,
     validateUser: () => `/rest/v1.1/sites/${this.site}/posts?number=1`,
     uploadFile: () => `/rest/v1.1/sites/${this.site}/media/new`,
+    setAlt: () => `/rest/v1.1/sites/${this.site}/media/<%= id %>/edit`,
     getPostTypes: () => `/rest/v1.1/sites/${this.site}/post-types`,
   };
 
@@ -381,7 +390,8 @@ export class WpRestClientWpComOAuth2Context implements WpRestClientContext {
       if (response.media.length > 0) {
         const media = response.media[0];
         return {
-          url: media.link
+          url: media.link,
+          mediaId: media.ID
         };
       } else if (response.errors) {
         throw new Error(response.errors.error.message);

--- a/src/wp-rest-client.ts
+++ b/src/wp-rest-client.ts
@@ -185,6 +185,19 @@ export class WpRestClient extends AbstractWordPressClient {
           formItemNameMapper: this.context.formItemNameMapper
         });
       const result = this.context.responseParser.toWordPressMediaUploadResult(response);
+
+      const altResponse: SafeAny = await this.client.httpPost(
+        getUrl(undefined, 'wp-json/wp/v2/media/' + result.mediaId),
+        JSON.stringify({
+          alt_text: media.alt
+        }),
+        {
+          headers: {
+            ...this.context.getHeaders(certificate)
+          }
+        }
+      )
+
       return {
         code: WordPressClientReturnCode.OK,
         data: result,
@@ -276,7 +289,8 @@ class WpRestClientCommonContext implements WpRestClientContext {
     },
     toWordPressMediaUploadResult: (response: SafeAny): WordPressMediaUploadResult => {
       return {
-        url: response.source_url
+        url: response.source_url,
+        mediaId: response.id
       };
     },
     toTerms: (response: SafeAny): Term[] => {


### PR DESCRIPTION
resolves #11
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for ALT text in image uploads using standard Markdown syntax, updating media upload functions and interfaces accordingly.
> 
>   - **Behavior**:
>     - Support for ALT text in image uploads using standard Markdown syntax in `abstract-wp-client.ts`.
>     - Updates `uploadMedia` in `abstract-wp-client.ts` to include `alt` text in media upload.
>     - Modifies `getImages` function to parse ALT text from Markdown.
>   - **Models**:
>     - Adds optional `alt` property to `Media` interface in `types.ts`.
>     - Updates `WordPressMediaUploadResult` in `wp-client.ts` to include `mediaId`.
>   - **REST Client**:
>     - Adds `setAlt` endpoint in `WpRestEndpoint` in `wp-rest-client.ts`.
>     - Updates `uploadMedia` in `wp-rest-client.ts` to set ALT text after media upload.
>   - **Misc**:
>     - Updates `toWordPressMediaUploadResult` in `WpRestClientCommonContext` and `WpRestClientWpComOAuth2Context` to handle `mediaId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=bugparty%2Fobsidian-wordpress-reloaded&utm_source=github&utm_medium=referral)<sup> for b102f3ba78f0a0a1c8431049fdf1ad8dc8b2068c. You can [customize](https://app.ellipsis.dev/bugparty/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Media uploads now capture and preserve alt text for uploaded images.
  * When inserting images into posts, alt text is automatically included in the markdown format.
  * Alt text metadata is maintained throughout the media upload and insertion workflow for improved accessibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->